### PR TITLE
Add back the ability to run single tests on a clean database

### DIFF
--- a/packages/comments-backend-core/README.md
+++ b/packages/comments-backend-core/README.md
@@ -47,10 +47,22 @@ docker-compose up postgres
 
 ### Run tests
 
-Once the db is up, to run the tests use
+Once the db is up, you need to create the database
+
+```
+npm run pg:test:init
+```
+
+and the run
 
 ```
 npm test
+```
+
+To run a single test you can use the following command
+
+```
+npx lab <test/to/run.js> // (ie: npx lab test/lib/comments.test.js)
 ```
 
 ## License

--- a/packages/comments-backend-core/package.json
+++ b/packages/comments-backend-core/package.json
@@ -28,7 +28,7 @@
     "pg:init": "node ./database/init.js && npm run pg:migrate",
     "pg:test:init": "NODE_ENV=test node ./database/init.js && NODE_ENV=test npm run pg:migrate",
     "pg:migrate": "node ./database/migrate.js max",
-    "test": "NODE_ENV=test npm run pg:test:init && NODE_ENV=test lab test"
+    "test": "NODE_ENV=test lab test"
   },
   "dependencies": {
     "@nearform/sql": "^1.0.1",

--- a/packages/comments-backend-core/test/lib/comments.test.js
+++ b/packages/comments-backend-core/test/lib/comments.test.js
@@ -5,13 +5,16 @@ const Lab = require('lab')
 module.exports.lab = Lab.script()
 const { describe, it: test, beforeEach, before, after } = module.exports.lab
 
+const { resetDb } = require('../utils')
 const config = require('../../config')
 const { random, lorem, name, internet } = require('faker')
 
 const { buildPool, buildCommentsService } = require('../../lib')
 
 describe('Comments', () => {
-  before(() => {
+  before(async () => {
+    await resetDb()
+
     const db = buildPool(config.pg)
     this.commentsService = buildCommentsService(db)
   })

--- a/packages/comments-backend-core/test/lib/hooks.test.js
+++ b/packages/comments-backend-core/test/lib/hooks.test.js
@@ -5,13 +5,16 @@ const Lab = require('lab')
 module.exports.lab = Lab.script()
 const { describe, it: test, beforeEach, before, after } = module.exports.lab
 
+const { resetDb } = require('../utils')
 const config = require('../../config')
 const { random, lorem, name, internet } = require('faker')
 
 const { buildPool, buildCommentsService } = require('../../lib')
 
 describe('Hooks', () => {
-  before(() => {
+  before(async () => {
+    await resetDb()
+
     const db = buildPool(config.pg)
     this.commentsService = buildCommentsService(db, {
       fetchedComment: async (comment) => {

--- a/packages/comments-backend-core/test/utils.js
+++ b/packages/comments-backend-core/test/utils.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const path = require('path')
+const SQL = require('@nearform/sql')
+const Postgrator = require('postgrator')
+
+const config = require('../config')
+const buildPool = require('../lib/dbPool')
+
+module.exports = { resetDb }
+
+async function resetDb () {
+  if (!config.isTest) {
+    console.log('Cannot run resetDb if not on testing env') // eslint-disable-line no-console
+    process.exit(1)
+  }
+
+  try {
+    const pool = buildPool(config.pg)
+
+    await checkDatabaseExists(pool, config.pg.database)
+    await resetTables(pool)
+    await pool.end()
+    await runMigrations(config.pg)
+  } catch (e) {
+    console.error(e) // eslint-disable-line no-console
+    process.exit(1)
+  }
+}
+
+async function checkDatabaseExists (pool, database) {
+  // if the databse do not exists the query will throw because we are connectiong on that db in config.pg
+  return pool.query(SQL`SELECT * FROM pg_database WHERE datname=${database}`)
+}
+
+async function resetTables (pool) {
+  await pool.query(`DROP TABLE IF EXISTS schemaversion`)
+  await pool.query(`DROP TABLE IF EXISTS comment`)
+}
+
+async function runMigrations (conf) {
+  const postgrator = new Postgrator({
+    migrationDirectory: path.join(__dirname, '../database/migrations'),
+    driver: 'pg',
+    host: conf.host,
+    port: conf.port,
+    database: conf.database,
+    username: conf.user,
+    password: conf.password,
+    schemaTable: 'schemaversion'
+  })
+
+  await postgrator.migrate('max')
+}

--- a/packages/comments-backend-hapi-plugin/README.md
+++ b/packages/comments-backend-hapi-plugin/README.md
@@ -41,6 +41,28 @@ When adding the `comments-backend-hapi-plugin` you can pass some hooks. These ho
 
 Those 2 functions should be either async or return a promise that will yeld the final augmented comment/comments list as its result.
 
+## Run tests
+
+You will need a postgres server up and running.
+
+To create the db needed for the tests you can use the following command
+
+```
+npm run pg:test:init
+```
+
+and the run
+
+```
+npm test
+```
+
+To run a single test you can use the following command
+
+```
+npx lab <test/to/run.js> // (ie: npx lab test/index.test.js)
+```
+
 ## License
 
 Copyright nearForm Ltd 2018. Licensed under [Apache 2.0 license][license].

--- a/packages/comments-backend-hapi-plugin/package.json
+++ b/packages/comments-backend-hapi-plugin/package.json
@@ -24,9 +24,9 @@
   "main": "lib/index.js",
   "scripts": {
     "coverage": "NODE_ENV=test lab test -c",
-    "pg:init": "NODE_ENV=test node ../comments-backend-core/database/init.js && NODE_ENV=test node ../comments-backend-core/database/migrate.js max",
+    "pg:test:init": "NODE_ENV=test node ../comments-backend-core/database/init.js && NODE_ENV=test node ../comments-backend-core/database/migrate.js max",
     "depcheck": "../../node_modules/depcheck/bin/depcheck",
-    "test": "npm run pg:init && NODE_ENV=test lab test"
+    "test": "NODE_ENV=test lab test"
   },
   "dependencies": {
     "@nearform/comments-backend-core": "^0.1.0",

--- a/packages/comments-backend-hapi-plugin/test/index.test.js
+++ b/packages/comments-backend-hapi-plugin/test/index.test.js
@@ -7,12 +7,14 @@ const { random, lorem, name, internet } = require('faker')
 module.exports.lab = Lab.script()
 const { describe, it: test, before, after, beforeEach } = module.exports.lab
 
+const { resetDb } = require('../../comments-backend-core/test/utils')
 const buildServer = require('./test-server')
 
 describe('Comments REST API', () => {
   let server = null
 
   before(async () => {
+    await resetDb()
     server = await buildServer()
   })
 

--- a/packages/comments-backend-hapi-server/README.md
+++ b/packages/comments-backend-hapi-server/README.md
@@ -18,6 +18,28 @@ npx run comments-backend-hapi-server
 
 This will start a server on `localhost:8080`.
 
+## Run tests
+
+You will need a postgres server up and running.
+
+To create the db needed for the tests you can use the following command
+
+```
+npm run pg:test:init
+```
+
+and the run
+
+```
+npm test
+```
+
+To run a single test you can use the following command
+
+```
+npx lab <test/to/run.js> // (ie: npx lab test/index.test.js)
+```
+
 ## License
 
 Copyright nearForm Ltd 2018. Licensed under [Apache 2.0 license][license].

--- a/packages/comments-backend-hapi-server/package.json
+++ b/packages/comments-backend-hapi-server/package.json
@@ -24,10 +24,10 @@
   "main": "lib/index.js",
   "scripts": {
     "coverage": "NODE_ENV=test lab --coverage-exclude config test -c",
-    "pg:init": "NODE_ENV=test node ../comments-backend-core/database/init.js && NODE_ENV=test node ../comments-backend-core/database/migrate.js max",
+    "pg:test:init": "NODE_ENV=test node ../comments-backend-core/database/init.js && NODE_ENV=test node ../comments-backend-core/database/migrate.js max",
     "depcheck": "../../node_modules/depcheck/bin/depcheck",
     "start": "node start.js",
-    "test": "npm run pg:init && NODE_ENV=test lab test"
+    "test": "NODE_ENV=test lab test"
   },
   "dependencies": {
     "@nearform/comments-backend-hapi-plugin": "^0.1.0",

--- a/packages/comments-backend-hapi-server/test/index.test.js
+++ b/packages/comments-backend-hapi-server/test/index.test.js
@@ -6,11 +6,13 @@ const Lab = require('lab')
 module.exports.lab = Lab.script()
 const { describe, it: test, before, after } = module.exports.lab
 
+const { resetDb } = require('../../comments-backend-core/test/utils')
 const buildServer = require('../lib/server')
 
 describe('Server', () => {
   let server = null
   before(async () => {
+    await resetDb()
     server = await buildServer()
   })
 


### PR DESCRIPTION
This PR adds back the `resetDb` and make sure a test can be run singularly (`npx lab test/some-test.js`).

The `resetDb` function will be used by tests to reset the data in the db so that they can have a clean state to start with. `resetDb` is isolated and will run only on `TEST` env. 

As a note: @codeflyer @ShogunPanda My ideal project is one where I download the repo, install dependency and with a single command run the tests. At the moment we need a step to manually create the db and I'd like to make that go away :) would that be fine by you?