### PR TITLE
feat(comment-state): added direct reference to provider state from th…

### DIFF
--- a/packages/comments-react-components/src/components/CommentableProvider.jsx
+++ b/packages/comments-react-components/src/components/CommentableProvider.jsx
@@ -12,10 +12,9 @@ export class CommentableProvider extends React.Component {
     super(props)
     this.logger = this.props.logger || console
 
-    this.commentsState = new CommentsState(this.props.service, this.onCommentsStateUpdate.bind(this))
+    this.commentsState = new CommentsState(this.props.service, this.getProviderState.bind(this), this.onCommentsStateUpdate.bind(this))
 
     this.state = {
-      ...this.commentsState.defaultState,
       logger: this.logger,
       toggledReference: null,
 
@@ -30,6 +29,10 @@ export class CommentableProvider extends React.Component {
 
   getCurrentResource() {
     return this.props.resource
+  }
+
+  getProviderState() {
+    return this.state
   }
 
   onCommentsStateUpdate(newState) {

--- a/packages/comments-react-components/src/state/Comments.js
+++ b/packages/comments-react-components/src/state/Comments.js
@@ -10,23 +10,34 @@ export class Comment {
 
 const defaultState = { comments: [] }
 
+export const STATE_FIELD_NAME = 'commentsState'
+
 export class CommentsState {
-  constructor(service, onCommentsStateUpdate) {
+  constructor(service, getProviderState, onCommentsStateUpdate) {
     this.service = service
+    this.getProviderState = getProviderState
     this.onCommentsStateUpdate = onCommentsStateUpdate
-    this.localState = defaultState
+  }
+
+  get state() {
+    return this.getProviderState()[STATE_FIELD_NAME] || {}
   }
 
   get defaultState() {
     return defaultState
   }
 
+  updateState(state) {
+    const newState = Object.assign({}, this.state, state)
+    this.onCommentsStateUpdate({ [STATE_FIELD_NAME]: newState })
+  }
+
   async refresh(resource) {
     const result = await this.service.getComments(resource)
     const newCommentList = []
     result.forEach(comment => newCommentList.push(new Comment(comment)))
-    this.localState = Object.assign({}, this.localState, { comments: newCommentList })
-    this.onCommentsStateUpdate(this.localState)
+
+    this.updateState({ comments: newCommentList })
   }
 
   async removeComment(comment) {

--- a/packages/comments-react-components/src/state/selectors.js
+++ b/packages/comments-react-components/src/state/selectors.js
@@ -1,4 +1,10 @@
-export const selectCommentsByReference = (state, referenceId) =>
-  (state.comments || []).filter(comment => comment.reference === referenceId)
+import { STATE_FIELD_NAME } from './Comments'
 
-export const totalCommentsCount = (state) => (state.comments || []).length
+const getCommentsState = state => {
+  return state[STATE_FIELD_NAME] || {}
+}
+
+export const selectCommentsByReference = (state, referenceId) =>
+  (getCommentsState(state).comments || []).filter(comment => comment.reference === referenceId)
+
+export const totalCommentsCount = (state) => (getCommentsState(state).comments || []).length

--- a/packages/comments-react-components/test/components/CommentableBlock.test.jsx
+++ b/packages/comments-react-components/test/components/CommentableBlock.test.jsx
@@ -3,16 +3,18 @@ import { mount } from 'enzyme'
 
 import { CommentableBlockComponent } from '../../src/components/CommentableBlock'
 import { CommentsInMemoryService } from '../helpers/CommentsInMemoryService'
-import { CommentsState } from '../../src/state/Comments'
+import { CommentsState, STATE_FIELD_NAME } from '../../src/state/Comments'
 
 describe('CommentableBlockComponent', () => {
   let events
   let wrapper
-  let commentable
+  let commentableState
 
   const setState = newState => {
-    commentable = Object.assign({}, commentable, newState)
+    commentableState = Object.assign({}, commentableState, newState)
   }
+
+  const getState = () => commentableState
 
   beforeEach(() => {
     events = {
@@ -24,23 +26,24 @@ describe('CommentableBlockComponent', () => {
       onSelect: jest.fn()
     }
 
-    commentable = {
+    commentableState = {
       toggledReference: 'block-1',
       toggleComments: jest.fn(),
       addComment: jest.fn(),
       removeComment: jest.fn(),
-      getReferenceComments: jest.fn()
+      getReferenceComments: jest.fn(),
+      [STATE_FIELD_NAME]: {}
     }
   })
 
   test('if comments are present the block should contain a marker', async () => {
-    const commentObject = new CommentsState(new CommentsInMemoryService(), setState)
+    const commentObject = new CommentsState(new CommentsInMemoryService(), getState, setState)
     await commentObject.addComment({ resource: 'page-1', reference: 'block-1', content: 'This is a comment' })
     await commentObject.addComment({ resource: 'page-1', reference: 'block-1', content: 'This is a comment 2' })
     await commentObject.addComment({ resource: 'page-1', reference: 'block-1', content: 'This is a comment 3' })
 
     wrapper = mount(
-      <CommentableBlockComponent referenceId="block-1" commentable={commentable} events={events}>
+      <CommentableBlockComponent referenceId="block-1" commentable={commentableState} events={events}>
         <div className="my-content">Some content</div>
       </CommentableBlockComponent>
     )
@@ -49,7 +52,7 @@ describe('CommentableBlockComponent', () => {
 
   test('if comments are not present the block should not contain a marker', () => {
     wrapper = mount(
-      <CommentableBlockComponent referenceId="block-1" commentable={commentable} events={events}>
+      <CommentableBlockComponent referenceId="block-1" commentable={commentableState} events={events}>
         <div className="my-content">Some content</div>
       </CommentableBlockComponent>
     )
@@ -72,14 +75,14 @@ describe('CommentableBlockComponent', () => {
   })
 
   test('if the component is toggled then the classname should be highlighted', () => {
-    commentable.getReferenceComments.mockReturnValue([])
+    commentableState.getReferenceComments.mockReturnValue([])
 
     wrapper = mount(
       <CommentableBlockComponent
         referenceId="block-1"
         className="classname"
         highlightedClassName="highlighted-classname"
-        commentable={Object.assign({}, commentable, { toggledReference: 'block-1' })}
+        commentable={Object.assign({}, commentableState, { toggledReference: 'block-1' })}
         events={events}
       >
         <div className="my-content">Some content</div>
@@ -101,14 +104,14 @@ describe('CommentableBlockComponent', () => {
   })
 
   test('if the component is toggled then the classname should be highlighted', () => {
-    commentable.getReferenceComments.mockReturnValue([])
+    commentableState.getReferenceComments.mockReturnValue([])
 
     wrapper = mount(
       <CommentableBlockComponent
         referenceId="block-1"
         className="classname"
         highlightedClassName="highlighted-classname"
-        commentable={Object.assign({}, commentable, { toggledReference: 'block-2' })}
+        commentable={Object.assign({}, commentableState, { toggledReference: 'block-2' })}
         events={events}
       >
         <div className="my-content">Some content</div>

--- a/packages/comments-react-components/test/components/CommentableSidebar.test.jsx
+++ b/packages/comments-react-components/test/components/CommentableSidebar.test.jsx
@@ -9,28 +9,30 @@ import { CommentsState } from '../../src/state/Comments'
 import { sidebarClassName } from '../../stories/components/styling'
 
 describe('CommentableSidebarComponent', () => {
-  let commentable
+  let commentableState
   let wrapper
   let formComponent
 
   const setState = newState => {
-    commentable = Object.assign({}, commentable, newState)
+    commentableState = Object.assign({}, commentableState, newState)
   }
 
+  const getState = () => commentableState
+
   beforeEach(async () => {
-    commentable = {
+    commentableState = {
       toggledReference: 'block-1',
       toggleComments: jest.fn(),
       addComment: jest.fn(),
       removeComment: jest.fn()
     }
 
-    const commentObject = new CommentsState(new CommentsInMemoryService(), setState)
+    const commentObject = new CommentsState(new CommentsInMemoryService(), getState, setState)
     await commentObject.addComment({ resource: 'page-1', reference: 'block-1', content: 'This is a comment' })
     await commentObject.addComment({ resource: 'page-1', reference: 'block-1', content: 'This is a comment 2' })
     await commentObject.addComment({ resource: 'page-1', reference: 'block-1', content: 'This is a comment 3' })
 
-    wrapper = mount(<CommentableSidebarComponent commentable={commentable} className={sidebarClassName} />)
+    wrapper = mount(<CommentableSidebarComponent commentable={commentableState} className={sidebarClassName} />)
     formComponent = wrapper.find('div[data-role="form"]')
   })
 
@@ -52,7 +54,7 @@ describe('CommentableSidebarComponent', () => {
         .find('button')
         .at(1)
         .simulate('click')
-      expect(commentable.addComment).toHaveBeenCalledWith('block-1', 'new value')
+      expect(commentableState.addComment).toHaveBeenCalledWith('block-1', 'new value')
     })
 
     test('should not call the add comment if the text trimmed is empty ', () => {
@@ -62,7 +64,7 @@ describe('CommentableSidebarComponent', () => {
         .find('button')
         .at(1)
         .simulate('click')
-      expect(commentable.addComment).not.toHaveBeenCalled()
+      expect(commentableState.addComment).not.toHaveBeenCalled()
     })
 
     test('should call the add comment if the text is trimmed and not empty', () => {
@@ -72,7 +74,7 @@ describe('CommentableSidebarComponent', () => {
         .find('button')
         .at(1)
         .simulate('click')
-      expect(commentable.addComment).toHaveBeenCalledWith('block-1', 'new value')
+      expect(commentableState.addComment).toHaveBeenCalledWith('block-1', 'new value')
     })
 
     test('should not call the add comment if the text area has no value', () => {
@@ -80,14 +82,14 @@ describe('CommentableSidebarComponent', () => {
         .find('button')
         .at(1)
         .simulate('click')
-      expect(commentable.addComment).not.toHaveBeenCalled()
+      expect(commentableState.addComment).not.toHaveBeenCalled()
     })
   })
 
   describe('Click on "Hide"', () => {
     test('should call the toggleComments', () => {
       wrapper.find('a[data-role="close"]').simulate('click')
-      expect(commentable.toggleComments).toHaveBeenCalled()
+      expect(commentableState.toggleComments).toHaveBeenCalled()
     })
   })
 
@@ -110,7 +112,7 @@ describe('CommentableSidebarComponent', () => {
         .at(0)
         .find('button')
         .simulate('click')
-      expect(commentable.removeComment).toHaveBeenCalledWith({
+      expect(commentableState.removeComment).toHaveBeenCalledWith({
         id: 1,
         content: 'This is a comment',
         reference: 'block-1',
@@ -126,7 +128,7 @@ describe('CommentableSidebarComponent', () => {
       formComponent.find('textarea').simulate('change')
       formComponent.find('textarea').simulate('keypress', { key: 'Enter', shiftKey: false })
       await sleep(50)
-      expect(commentable.addComment).toHaveBeenCalledWith('block-1', 'new value')
+      expect(commentableState.addComment).toHaveBeenCalledWith('block-1', 'new value')
     })
 
     test('should not call the add comment if shift is pressed', async () => {
@@ -134,7 +136,7 @@ describe('CommentableSidebarComponent', () => {
       formComponent.find('textarea').simulate('change')
       formComponent.find('textarea').simulate('keypress', { key: 'Enter', shiftKey: true })
       await sleep(50)
-      expect(commentable.addComment).not.toHaveBeenCalled()
+      expect(commentableState.addComment).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/comments-react-components/test/state/Comments.test.js
+++ b/packages/comments-react-components/test/state/Comments.test.js
@@ -1,14 +1,17 @@
 import { selectCommentsByReference, totalCommentsCount } from '../../src/state/selectors'
-import { CommentsState } from '../../src/state/Comments'
+import { CommentsState, STATE_FIELD_NAME } from '../../src/state/Comments'
 
 import { CommentsInMemoryService } from '../helpers/CommentsInMemoryService'
 
 describe('Comments', () => {
-  let state = {}
+  let state
   const setState = newState => (state = Object.assign({}, state, newState))
+  const getState = () => state
 
   beforeEach(() => {
-    state = {}
+    state = {
+      [STATE_FIELD_NAME]: {}
+    }
   })
 
   describe('When a new instance is created', () => {
@@ -21,7 +24,7 @@ describe('Comments', () => {
     let comments
 
     beforeEach(async () => {
-      comments = new CommentsState(new CommentsInMemoryService(), setState)
+      comments = new CommentsState(new CommentsInMemoryService(), getState, setState)
       await comments.addComment({
         resource: 'page-1',
         reference: 'comm-1',
@@ -51,7 +54,7 @@ describe('Comments', () => {
   describe('Removing a comment', () => {
     let comments
     beforeEach(async () => {
-      comments = new CommentsState(new CommentsInMemoryService(), setState)
+      comments = new CommentsState(new CommentsInMemoryService(), getState, setState)
       await comments.addComment({
         resource: 'page-1',
         reference: 'comm-2',
@@ -81,7 +84,7 @@ describe('Comments', () => {
   describe('Get comments by reference', () => {
     let comments
     beforeEach(() => {
-      comments = new CommentsState(new CommentsInMemoryService(), setState)
+      comments = new CommentsState(new CommentsInMemoryService(), getState, setState)
       comments.addComment({ url: 'url1', reference: 'comm-1', content: 'somecontent 1' })
       comments.addComment({ url: 'url1', reference: 'comm-1', content: 'somecontent 2' })
       comments.addComment({ url: 'url1', reference: 'comm-2', content: 'somecontent 3' })


### PR DESCRIPTION
In this PR another refactoring was made to the CommentState.

Now isn't used anymore a local state, in The CommentsState component everytime the state is required is called a method that returns the state from the provider.
