### PR TITLE
Make author as nullable field

### DIFF
--- a/packages/comments-backend-core/README.md
+++ b/packages/comments-backend-core/README.md
@@ -130,7 +130,7 @@ async function myFn () => {
     resource: 'some-resource',
     reference: 'some-reference',
     content: 'some content',
-    author: 'author'
+    author: 'author' // optional
   }
   const created = await commentsService.add(comment)
 

--- a/packages/comments-backend-core/database/migrations/001.do.comment-table.sql
+++ b/packages/comments-backend-core/database/migrations/001.do.comment-table.sql
@@ -3,6 +3,6 @@ CREATE TABLE comment (
   resource varchar(2048) NOT NULL,
   reference varchar(512) NOT NULL,
   content text NOT NULL,
-  author varchar(255) NOT NULL,
+  author varchar(255) NULL,
   created_at timestamp with time zone NOT NULL DEFAULT NOW()
 );

--- a/packages/comments-backend-core/test/lib/comments.test.js
+++ b/packages/comments-backend-core/test/lib/comments.test.js
@@ -32,7 +32,7 @@ describe('Comments', () => {
         resource: this.resource,
         reference: i === 0 ? this.reference : random.uuid(),
         content: lorem.words(),
-        author: name.firstName()
+        author: i < 15 ? name.firstName() : null
       }))
 
       return Promise.all(comments.map(comment => this.commentsService.add(comment)))
@@ -88,8 +88,7 @@ describe('Comments', () => {
       const comment = {
         resource: 'http://example.com/example',
         reference: 'uuid-of-some-sort',
-        content: 'lorm ipsum ....',
-        author: 'Filippo'
+        content: 'lorm ipsum ....'
       }
 
       const result = await this.commentsService.add(comment)

--- a/packages/comments-backend-hapi-plugin/README.md
+++ b/packages/comments-backend-hapi-plugin/README.md
@@ -169,7 +169,7 @@ The list is paginated based on `limit` (default 100) and `offset` (default 0) pa
 
 This endpoint will create a new comment.
 
-The body of the request is as follow and all parameters are required
+The body of the request is as follow and all parameters but author are required
 
 ```
 POST /comments

--- a/packages/comments-backend-hapi-plugin/lib/routes.js
+++ b/packages/comments-backend-hapi-plugin/lib/routes.js
@@ -65,7 +65,7 @@ module.exports = {
             resource: Joi.string().required(),
             reference: Joi.string().required(),
             content: Joi.string().required(),
-            author: Joi.string().required()
+            author: Joi.string().optional()
           }
         }
       }


### PR DESCRIPTION
This PR makes the `author` field nullable.

The frontend will not have to send it along anymore, and we can keep it for future enhancement.