### PR TITLE
feat(user-resolver): moved resolver on username property

### DIFF
--- a/packages/commentami-backend-hapi-plugin/lib/routes.js
+++ b/packages/commentami-backend-hapi-plugin/lib/routes.js
@@ -62,8 +62,8 @@ module.exports = {
       handler: async function(request, h) {
         const user = options.getUserFromRequest
           ? await options.getUserFromRequest(request, request.payload)
-          : { id: null }
-        const payload = Object.assign({}, request.payload, user.id ? { author: '' + user.id } : null)
+          : { username: null }
+        const payload = Object.assign({}, request.payload, user.username ? { author: '' + user.username } : null)
 
         return request.commentsService.add(payload)
       },

--- a/packages/commentami-backend-hapi-plugin/test/test-server.js
+++ b/packages/commentami-backend-hapi-plugin/test/test-server.js
@@ -63,7 +63,7 @@ const fakeAuthPlugin = {
   },
   validate: async (request, authorization, h) => {
     if (authorization) {
-      return { isValid: true, credentials: { id: 'test' } }
+      return { isValid: true, credentials: { username: 'test' } }
     }
 
     return { isValid: false }

--- a/packages/commentami-demo-server/lib/auth.js
+++ b/packages/commentami-demo-server/lib/auth.js
@@ -11,7 +11,7 @@ const passwords = {
 
 const users = {
   filippo: {
-    id: 'filippo',
+    id: 1,
     username: 'filippo',
     firstName: 'Filippo',
     lastName: 'Test',
@@ -19,7 +19,7 @@ const users = {
     profileUrl: 'https://www.google.com'
   },
   paolo: {
-    id: 'paolo',
+    id: 2,
     username: 'paolo',
     firstName: 'Paolo',
     lastName: 'Test',
@@ -27,7 +27,7 @@ const users = {
     profileUrl: 'https://www.google.com'
   },
   davide: {
-    id: 'davide',
+    id: 3,
     username: 'davide',
     firstName: 'Davide',
     lastName: 'Test',
@@ -35,7 +35,7 @@ const users = {
     profileUrl: 'https://www.google.com'
   },
   test: {
-    id: 'test',
+    id: 4,
     username: 'test',
     firstName: 'test',
     lastName: 'test',

--- a/packages/commentami-demo-server/test/http-rest-api.test.js
+++ b/packages/commentami-demo-server/test/http-rest-api.test.js
@@ -59,7 +59,7 @@ describe('Server', () => {
         expect(result.content).to.equal(created.content)
         expect(result.author).to.be.object()
         expect(result.author).to.equal({
-          id: 'test',
+          id: 4,
           username: 'test',
           firstName: 'test',
           lastName: 'test',


### PR DESCRIPTION
Changed the user resolver in the POST /comments, now it works using `username` instead of `id`