### PR TITLE
Make components build before publishing on npm

### DIFF
--- a/packages/commentami-react-components/README.md
+++ b/packages/commentami-react-components/README.md
@@ -12,6 +12,7 @@ To explore components, use storybook:
 
 ```
 npm install
+npm run build
 npm run storybook
 ```
 

--- a/packages/commentami-react-components/package.json
+++ b/packages/commentami-react-components/package.json
@@ -38,10 +38,10 @@
     "build": "babel -d dist src",
     "build:watch": "babel -d dist --watch src",
     "clean": "rm -rf dist",
-    "postinstall": "npm run build",
     "storybook": "start-storybook -p 6006 -c .storybook",
     "test": "node test/start.js",
-    "test:watch": "WATCH=true node test/start.js"
+    "test:watch": "WATCH=true node test/start.js",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "nes": "^8.1.0",


### PR DESCRIPTION
This PR should configure the publishing to npm so that the components build is done before it.