### PR TITLE
bump hapi to v18 (and bump other dependencies too)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Copyright nearForm Ltd 2018. Licensed under [Apache 2.0 license][license].
 
 ## Contributing
 
-We have a [contributing guide](contributing) and a [code of conduct](coc).
+We have a [contributing guide][contributing] and a [code of conduct][coc].
 
 [commentami-backend-core]: https://www.npmjs.com/package/@nearform/commentami-backend-core
 [commentami-backend-hapi-plugin]: https://www.npmjs.com/package/@nearform/commentami-backend-hapi-plugin

--- a/packages/commentami-backend-hapi-plugin/package.json
+++ b/packages/commentami-backend-hapi-plugin/package.json
@@ -38,16 +38,16 @@
   },
   "dependencies": {
     "@nearform/commentami-backend-core": "^1.0.5",
-    "joi": "^13.3.0",
+    "joi": "^14.3.1",
     "multines": "^1.0.0",
-    "nes": "^9.0.0"
+    "nes": "^10.0.0"
   },
   "devDependencies": {
     "boom": "^7.2.0",
     "code": "^5.2.0",
     "faker": "^4.1.0",
-    "hapi": "^17.5.0",
-    "lab": "^15.4.5"
+    "hapi": "^18.1.0",
+    "lab": "^18.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/commentami-demo-server/package.json
+++ b/packages/commentami-demo-server/package.json
@@ -39,15 +39,15 @@
   },
   "dependencies": {
     "@nearform/commentami-backend-hapi-plugin": "^1.0.6",
-    "hapi": "^17.5.0",
+    "hapi": "^18.1.0",
     "hapi-auth-basic": "^5.0.0",
-    "hapi-pino": "^4.0.4",
+    "hapi-pino": "^5.4.1",
     "lodash": "^4.17.10"
   },
   "devDependencies": {
     "code": "^5.2.0",
-    "lab": "^15.4.5",
-    "nes": "^9.0.0",
+    "lab": "^18.0.2",
+    "nes": "^10.0.0",
     "sinon": "^5.0.10"
   },
   "publishConfig": {


### PR DESCRIPTION
bumped dependencies in `commentami-backend-hapi-plugin` and `commentami-demo-server`